### PR TITLE
Jira Product Discovery Insights Support

### DIFF
--- a/BasicConnect.query.pq
+++ b/BasicConnect.query.pq
@@ -1,1 +1,7 @@
-Jira("drofus", null, "CNSLT", "10", null, null)
+let
+    Source = Jira("drofus", null, "CFR, PB", "2000", null, null),
+
+    issues = Source[JPDIssues]
+in
+    issues
+

--- a/BasicConnect.query.pq
+++ b/BasicConnect.query.pq
@@ -3,5 +3,4 @@ let
 
     issues = Source[JPDIssues]
 in
-    issues
-
+    Source

--- a/atlassianJiraConnector.pq
+++ b/atlassianJiraConnector.pq
@@ -1,4 +1,4 @@
-[Version = "1.0.7"]
+[Version = "1.0.8"]
 section atlassianJiraConnector;
 
 // Helper function to load .pqm files
@@ -19,6 +19,7 @@ Extension.LoadFunction = (fileName as text) =>
 
 //Load Module Groups
 JiraAPI = Extension.LoadFunction("jiraAPI.pqm");
+JiraInsights = Extension.LoadFunction("jiraInsights.pqm");
 JiraSchema = Extension.LoadFunction("jiraSchema.pqm");
 JiraTestSupport = Extension.LoadFunction("jiraTestSupport.pqm");
 helperFunctions = Extension.LoadFunction("helperFunctions.pqm");
@@ -29,6 +30,7 @@ buildJqlQuery = JiraAPI[buildJqlQuery];
 DiscoverMaxResults = JiraAPI[DiscoverMaxResults];
 jiraDataRetrievalSimple = JiraAPI[jiraDataRetrievalSimple];
 jiraDataRetrievalPaginated = JiraAPI[jiraDataRetrievalPaginated];
+getPolarisInsights = JiraInsights[SafeGetAllPolarisInsights];
 
 // Load schema functions
 issuesFieldsList = JiraSchema[issuesFieldsList];
@@ -412,75 +414,69 @@ jiraNavTbl =
                     })
                 in
                     issuesWithErrorHandling,
-            
-            JPDprojects = Table.SelectRows(getProjects, each [projectTypeKey] = "product_discovery"),
-            cloudId = credentials[Properties][cloud_id],
 
-            ConstructProjectARI = Table.AddColumn(JPDprojects, "ARI", each "ari:cloud:jira:" & cloudId & ":project/" & Text.From([id])),
-
-
-            accessToken = credentials[access_token],
-            JPDissues = issues[Issues]{1}[key],
-
-            projectARI = ConstructProjectARI[ARI]{0},
-            issueARI = "ari:cloud:jira:" & cloudId & ":issue/" & "134145",//List.First(JPDissues),
-
-            JPDgraphQL = /* (projectID as text, issuesList as list, accessToken as text) => */
+            //Get Jira Insights where applicable
+            processInsights =
                 let
-                    // Build GraphQL body with passed-in variables
-                    query = "
-                        query getPolarisInsights($project: ID!, $container: ID) {
-                            polarisInsights(project: $project, container: $container) {
-                                id
-                                description
-                                snippets {
-                                    id
-                                    data
-                                    url
-                                    properties
-                                }
-                            }
-                        }
-                    ",
-                    variables = [
-                        project = projectARI,
-                        container = issueARI
-                    ],
-                    // POST to the GraphQL endpoint
-                    response = Web.Contents(
-                        "https://api-private.atlassian.com/graphql",
-                        [
-                            Content = Json.FromValue([query=query, variables=variables]),
-                            Headers = [
-                                Authorization = "Bearer " & accessToken,
-                                Accept = "application/json",
-                                #"Content-Type" = "application/json",
-                                #"X-ExperimentalApi" = "polaris-v0"
-                            ],
-                            ManualCredentials = true
-                        ]
-                    ),
-                    json = Json.Document(response),
-                    hasErrors = Record.HasFields(json, "errors"),
-                    errorMessages = if hasErrors then Table.FromRecords(json[errors]) else json,
-                    ideasData = if not hasErrors and Record.HasFields(json, "data") then json[data][ideas][nodes] else {},
-
-                    outputTable =
-                        if List.IsEmpty(ideasData)
-                        then #table({"id", "key", "title", "created", "updated"}, {})
-                        else Table.FromRecords(ideasData)
-
-                    /*outputTable = if List.IsEmpty(ideasData) then
-                        #table({"id", "key", "title", "created", "updated"}, {})
-                    else
-                        Table.FromList(json, Record.FieldValues, {"id", "key", "title", "created", "updated"})*/
+                    hasJPD = List.Contains(getProjects[projectTypeKey], "product_discovery")
                 in
-                    //variables[container],
-                    [
-                        result = errorMessages,
-                        ARIvalues = variables,
-                        JPDIssues = issues
-                    ],
+                    AuthType = "OAuth3LO" and hasJPD,
+            cloudId = credentials[Properties][cloud_id],
+            accessToken = credentials[access_token],
+            jpdProjects =
+                if processInsights then
+                    let
+                        filterRows = Table.SelectRows(getProjects, each ([projectTypeKey] = "product_discovery")),
+                        selectColumns = Table.SelectColumns(filterRows,{"id", "key", "projectTypeKey", "name"}),
+                        mergeQueries = Table.NestedJoin(selectColumns, {"id"}, issues, {"id"}, "issueData", JoinKind.LeftOuter),
+                        expandIssues = Table.ExpandTableColumn(mergeQueries, "issueData", {"Issues"}, {"Issues"}),
+                        transformTable = Table.TransformColumns(expandIssues, { "Issues", each Table.SelectColumns(_, {"id", "key"})})
+                    in
+                        transformTable
+                else
+                    #table(
+                        Table.ColumnNames(getProjects),
+                        {}
+                    ),
+
+            insightsData =
+                if processInsights then
+                    let
+                        polarisData = getPolarisInsights(
+                            jpdProjects,
+                            cloudId,
+                            accessToken
+                        )
+                    in
+                        polarisData
+                else
+                    [NavigationTable = #table({"ProjectKey"}, {}), ProjectsInsights = []],
+
+
+
+
+           insightsForNav = 
+            if processInsights then
+                let
+                    navTable = insightsData[NavigationTable],
+                    projectInsights = insightsData[ProjectsInsights],
+                    
+                    // Transform each project into a navigation entry
+                    entries = Table.TransformRows(
+                        navTable,
+                        each {
+                            [ProjectKey] & " - " & [ProjectName],  // Name shown in navigator
+                            Record.Field(projectInsights, [ProjectKey])[InsightsTable],  // The insights table
+                            "Table",
+                            "Table",
+                            true  // IsLeaf
+                        }
+                    )
+                in
+                    entries
+            else
+                {},
+            
 
             //GraphQL Schema Introspection (for development/debugging purposes)
             /*
@@ -557,10 +553,27 @@ jiraNavTbl =
                 }
             },
 
+            entriesWithInsights =
+                if processInsights and List.Count(insightsForNav) > 0 then
+                    List.Combine({
+                        baseEntries,
+                        {
+                            {
+                                "Insights",
+                                createIssuesNavigationTable(insightsForNav),
+                                "Folder",
+                                "Folder",
+                                false
+                            }
+                        }
+                    })
+                else
+                    baseEntries,
+
             entriesWithValidation =
                 if projectValidation[HasInvalidKeys] or List.Count(requestedProjects) > 0 then
                     List.Combine({
-                        baseEntries,
+                        entriesWithInsights,
                         {
                             {
                                 "Project Filter Report",
@@ -583,5 +596,4 @@ jiraNavTbl =
             )
         in
             //JPDSchemaIntrospection;
-            JPDgraphQL;
-            //navTable;
+            navTable;

--- a/atlassianJiraConnector.pq
+++ b/atlassianJiraConnector.pq
@@ -270,7 +270,7 @@ jiraNavTbl =
     ) =>
         let
             credentials = try Extension.CurrentCredential() otherwise null,
-        //tempoary credentials debugging, return if needed to inspect credentials object
+        //temporay credentials debugging, return if needed to inspect credentials object
             deBugCredentials = deBugCredentials(credentials),
 
             AuthType =
@@ -318,8 +318,6 @@ jiraNavTbl =
                         )),
                         each _
                     ),
-            
-
 
             URL = ValidateUrlScheme(baseURL),
 
@@ -414,6 +412,130 @@ jiraNavTbl =
                     })
                 in
                     issuesWithErrorHandling,
+            
+            JPDprojects = Table.SelectRows(getProjects, each [projectTypeKey] = "product_discovery"),
+            cloudId = credentials[Properties][cloud_id],
+
+            ConstructProjectARI = Table.AddColumn(JPDprojects, "ARI", each "ari:cloud:jira:" & cloudId & ":project/" & Text.From([id])),
+
+
+            accessToken = credentials[access_token],
+            JPDissues = issues[Issues]{1}[key],
+
+            projectARI = ConstructProjectARI[ARI]{0},
+            issueARI = "ari:cloud:jira:" & cloudId & ":issue/" & "134145",//List.First(JPDissues),
+
+            JPDgraphQL = /* (projectID as text, issuesList as list, accessToken as text) => */
+                let
+                    // Build GraphQL body with passed-in variables
+                    query = "
+                        query getPolarisInsights($project: ID!, $container: ID) {
+                            polarisInsights(project: $project, container: $container) {
+                                id
+                                description
+                                snippets {
+                                    id
+                                    data
+                                    url
+                                    properties
+                                }
+                            }
+                        }
+                    ",
+                    variables = [
+                        project = projectARI,
+                        container = issueARI
+                    ],
+                    // POST to the GraphQL endpoint
+                    response = Web.Contents(
+                        "https://api-private.atlassian.com/graphql",
+                        [
+                            Content = Json.FromValue([query=query, variables=variables]),
+                            Headers = [
+                                Authorization = "Bearer " & accessToken,
+                                Accept = "application/json",
+                                #"Content-Type" = "application/json",
+                                #"X-ExperimentalApi" = "polaris-v0"
+                            ],
+                            ManualCredentials = true
+                        ]
+                    ),
+                    json = Json.Document(response),
+                    hasErrors = Record.HasFields(json, "errors"),
+                    errorMessages = if hasErrors then Table.FromRecords(json[errors]) else json,
+                    ideasData = if not hasErrors and Record.HasFields(json, "data") then json[data][ideas][nodes] else {},
+
+                    outputTable =
+                        if List.IsEmpty(ideasData)
+                        then #table({"id", "key", "title", "created", "updated"}, {})
+                        else Table.FromRecords(ideasData)
+
+                    /*outputTable = if List.IsEmpty(ideasData) then
+                        #table({"id", "key", "title", "created", "updated"}, {})
+                    else
+                        Table.FromList(json, Record.FieldValues, {"id", "key", "title", "created", "updated"})*/
+                in
+                    //variables[container],
+                    [
+                        result = errorMessages,
+                        ARIvalues = variables,
+                        JPDIssues = issues
+                    ],
+
+            //GraphQL Schema Introspection (for development/debugging purposes)
+            /*
+            JPDSchemaIntrospection = 
+                let
+                    // Introspection query to discover available fields on the Query type
+                    query = "
+                        query IntrospectSchema {
+                            __schema {
+                                queryType {
+                                    name
+                                    fields {
+                                        name
+                                        description
+                                        args {
+                                            name
+                                            type {
+                                                name
+                                                kind
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    ",
+                    
+                    // No variables needed for introspection
+                    response = Web.Contents(
+                        "https://api.atlassian.com/graphql?product=jira-product-discovery",
+                        [
+                            Content = Json.FromValue([query=query]),
+                            Headers = [
+                                Authorization = "Bearer " & accessToken,
+                                Accept = "application/json",
+                                #"Content-Type" = "application/json"
+                            ],
+                            ManualCredentials = true
+                        ]
+                    ),
+                    
+                    json = Json.Document(response),
+                    
+                    // Extract the fields list
+                    queryFields = json[data][__schema][queryType][fields],
+                    
+                    // Convert to table for easy viewing
+                    fieldsTable = Table.FromRecords(queryFields)
+                in
+                    fieldsTable,
+            */
+
+
+
+            
             issuesForNav = Table.TransformRows(issues, 
                         each {
                             [name],
@@ -460,4 +582,6 @@ jiraNavTbl =
                 source, {"Name"}, "Name", "Data", "ItemKind", "ItemName", "IsLeaf"
             )
         in
-            navTable;
+            //JPDSchemaIntrospection;
+            JPDgraphQL;
+            //navTable;

--- a/jiraInsights.pqm
+++ b/jiraInsights.pqm
@@ -1,195 +1,307 @@
-// jiraInsights.pqm
-// GraphQL queries for Jira Product Discovery (Polaris) Insights
+let
+    // ============================================================================
+    // POLARIS INSIGHTS API MODULE
+    // ============================================================================
+    // This module contains functions for querying Polaris insights from Jira Product Discovery
+    
+    // Main function: Get all Polaris insights for a list of issues in a project
+    GetPolarisInsightsForIssues = (
+        projectAri as text,
+        issueIds as list,
+        accessToken as text,
+        optional includeSnippets as logical
+    ) as table =>
+        let
+            validIssueIds = if issueIds = null or List.IsEmpty(issueIds) then
+                {}
+            else
+                issueIds,
+            
+            includeSnippets_actual = if includeSnippets = null then true else includeSnippets,
+            
+            // Function to query insights for a single issue
+            QuerySingleIssueInsights = (issueId as text, optional Ari as text, optional includeSnippet as logical, optional token as text) =>
+                let
+                    // Build the container ARI for the specific issue
+                    containerAri = Text.BeforeDelimiter(projectAri, ":project/") & ":issue/" & issueId,
+                    
+                    query = "
+                        query getPolarisInsights($project: ID!, $container: ID) {
+                            polarisInsights(project: $project, container: $container) {
+                                id
+                                description
+                                created
+                                updated
+                                " & (if includeSnippets_actual then "snippets {
+                                    id
+                                    data
+                                    url
+                                    properties
+                                }" else "") & "
+                            }
+                        }
+                    ",
+                    
+                    variables = [
+                        project = projectAri,
+                        container = containerAri
+                    ],
+                    
+                    response = Web.Contents(
+                        "https://api-private.atlassian.com/graphql",
+                        [
+                            Content = Json.FromValue([query=query, variables=variables]),
+                            Headers = [
+                                Authorization = "Bearer " & accessToken,
+                                #"Content-Type" = "application/json",
+                                #"X-ExperimentalApi" = "polaris-v0"
+                            ],
+                            ManualCredentials = true
+                        ]
+                    ),
+                    
+                    json = Json.Document(response),
+                    hasErrors = Record.HasFields(json, "errors"),
+                    
+                    // Extract insights or error data
+                    insightsData =
+                        if hasErrors then
+                            {}
+                        else if not Record.HasFields(json, "data") then
+                            {}
+                        else if json[data] = null then
+                            {}
+                        else if not Record.HasFields(json[data], "polarisInsights") then
+                            {}
+                        else 
+                            let
+                                rawInsights = json[data][polarisInsights]
+                            in
+                                if rawInsights = null then {} else rawInsights,
 
-section jiraInsights;
+                    safeInsightsData =
+                        if Value.Is(insightsData, List.Type) then
+                            insightsData
+                        else
+                            {},
 
-// Core GraphQL query executor with error handling
-shared jiraInsights.QueryGraphQL = (
-    query as text,
-    variables as record,
-    accessToken as text
-) as record =>
-    let
-        graphQLEndpoint = "https://api.atlassian.com/graphql",
-        
-        requestBody = [
-            query = query,
-            variables = variables
-        ],
-        
-        response = Web.Contents(
-            graphQLEndpoint,
-            [
-                Content = Json.FromValue(requestBody),
-                Headers = [
-                    Authorization = "Bearer " & accessToken,
-                    Accept = "application/json",
-                    #"Content-Type" = "application/json"
-                ],
-                ManualCredentials = true
-            ]
-        ),
-        
-        jsonResponse = Json.Document(response),
-        
-        // GraphQL always returns 200, check for errors in response
-        result = if Record.HasFields(jsonResponse, "errors") then
-            error Error.Record(
-                "GraphQL.QueryError", 
-                "GraphQL query failed: " & jsonResponse[errors]{0}[message]?,
-                jsonResponse
-            )
-        else
-            jsonResponse[data]
-    in
-        result;
-
-// Fetch Insights for a single project with pagination
-shared jiraInsights.GetProjectInsights = (
-    projectId as text,
-    containerId as nullable text,
-    accessToken as text,
-    optional afterCursor as nullable text
-) as record =>
-    let
-        query = "
-            query getPolarisInsights($project: ID!, $container: ID, $after: String) {
-              polarisInsights(
-                project: $project, 
-                container: $container,
-                first: 50,
-                after: $after
-              ) {
-                edges {
-                  cursor
-                  node {
-                    id
-                    description
-                    created
-                    updated
-                    snippets {
-                      id
-                      data
-                      url
-                      properties
-                      oauthClientId
-                    }
-                  }
-                }
-                pageInfo {
-                  hasNextPage
-                  endCursor
-                }
-              }
-            }
-        ",
-        
-        variables = [
-            project = projectId,
-            container = if containerId <> null then containerId else null,
-            after = if afterCursor <> null then afterCursor else null
-        ],
-        
-        data = jiraInsights.QueryGraphQL(query, variables, accessToken),
-        insights = data[polarisInsights]
-    in
-        insights;
-
-// Paginated fetch with recursive accumulation
-shared jiraInsights.GetAllProjectInsights = (
-    projectId as text,
-    projectKey as text,
-    projectName as text,
-    containerId as nullable text,
-    accessToken as text
-) as table =>
-    let
-        // Recursive function to accumulate paginated results
-        GetPage = (afterCursor as nullable text, accumulated as list) =>
-            let
-                page = jiraInsights.GetProjectInsights(projectId, containerId, accessToken, afterCursor),
-                edges = page[edges],
-                pageInfo = page[pageInfo],
-                
-                // Extract insights from edges
-                insights = List.Transform(edges, each [node]),
-                
-                // Combine with accumulated results
-                allInsights = List.Combine({accumulated, insights}),
-                
-                // Recursively fetch next page if available
-                result = if pageInfo[hasNextPage] then
-                    @GetPage(pageInfo[endCursor], allInsights)
+                    // Add metadata: issue ID and result status
+                    withMetadata = List.Transform(
+                        safeInsightsData,
+                        each _ & [
+                            IssueId = issueId,
+                            HasError = hasErrors,
+                            ErrorMessage = if hasErrors then 
+                                try json[errors]{0}[message] otherwise "Unknown error"
+                            else
+                                null
+                        ]
+                    )
+                in
+                    withMetadata,
+            
+            //Query all issues and combine results
+            allInsightsResults =
+                if List.IsEmpty(validIssueIds)
+                then {}
                 else
-                    allInsights
-            in
-                result,
-        
-        // Start pagination
-        allInsights = GetPage(null, {}),
-        
-        // Convert to table and add project context
-        insightsTable = if List.Count(allInsights) > 0 then
-            let
-                baseTable = Table.FromList(allInsights, Splitter.SplitByNothing(), {"Insight"}),
-                expandedTable = Table.ExpandRecordColumn(baseTable, "Insight", 
-                    {"id", "description", "created", "updated", "snippets"}, 
-                    {"InsightId", "InsightDescription", "InsightCreated", "InsightUpdated", "Snippets"}
-                ),
-                
-                // Add project context columns
-                withProject = Table.AddColumn(expandedTable, "ProjectId", each projectId, type text),
-                withKey = Table.AddColumn(withProject, "ProjectKey", each projectKey, type text),
-                withName = Table.AddColumn(withKey, "ProjectName", each projectName, type text),
-                
-                // Expand snippets
-                expandedSnippets = Table.ExpandListColumn(withName, "Snippets"),
-                finalTable = Table.ExpandRecordColumn(expandedSnippets, "Snippets",
-                    {"id", "data", "url", "properties", "oauthClientId"},
-                    {"SnippetId", "SnippetData", "SnippetUrl", "SnippetProperties", "SnippetOAuthClientId"}
-                )
-            in
-                finalTable
-        else
-            // Return empty table with schema if no insights
-            #table(
-                {"InsightId", "InsightDescription", "InsightCreated", "InsightUpdated", 
-                 "ProjectId", "ProjectKey", "ProjectName",
-                 "SnippetId", "SnippetData", "SnippetUrl", "SnippetProperties", "SnippetOAuthClientId"},
-                {}
-            )
-    in
-        insightsTable;
+                    List.Combine(
+                        List.Transform(validIssueIds, each QuerySingleIssueInsights(_))
+                    ),
 
-// Fetch Insights for multiple Product Discovery projects
-shared jiraInsights.GetInsightsForProjects = (
-    projects as table,
-    accessToken as text
-) as table =>
-    let
-        // Filter to only Product Discovery projects
-        discoveryProjects = Table.SelectRows(projects, 
-            each [projectTypeKey] = "com.atlassian.jira-polaris-plugin:jira-polaris-project-type"
-        ),
-        
-        // Add Insights column for each project
-        withInsights = Table.AddColumn(discoveryProjects, "Insights", 
-            each try jiraInsights.GetAllProjectInsights(
-                [id],
-                [key],
-                [name],
-                null, // container ID - typically null for project-level insights
-                accessToken
-            ) otherwise #table(
-                {"InsightId", "InsightDescription", "InsightCreated", "InsightUpdated",
-                 "ProjectId", "ProjectKey", "ProjectName",
-                 "SnippetId", "SnippetData", "SnippetUrl", "SnippetProperties", "SnippetOAuthClientId"},
-                {}
-            )
-        ),
-        
-        // Combine all insights into single table
-        insightsTables = Table.Column(withInsights, "Insights"),
-        combinedInsights = Table.Combine(insightsTables)
-    in
-        combinedInsights;
+            // Convert to table
+            outputTable =
+                if List.IsEmpty(allInsightsResults)
+                then
+                    #table(
+                        {"id", "description", "created", "updated", "snippets", "IssueId", "HasError", "ErrorMessage"},
+                        {}
+                    )
+                else
+                    let
+                        tbl = Table.FromRecords(allInsightsResults),
+                        //filter out issues with no insights
+                        filterNullRows = Table.SelectRows(tbl, each [description] <> null)
+                    in
+                        filterNullRows
+        in
+            outputTable,
+    
+    // Function: Get insights for all JPD projects and create navigation structure
+    GetAllPolarisInsights = (
+        projectsTable as table,
+        cloudId as text,
+        accessToken as text
+    ) as record =>
+        let
+            // Function to process a single JPD project
+            ProcessJPDProject = (projectRow as record) =>
+                let
+                    projectId = projectRow[id],
+                    projectKey = projectRow[key],
+                    projectName = projectRow[name],
+                    projectAri = "ari:cloud:jira:" & cloudId & ":project/" & Text.From(projectId),
+                    
+                    // Get issues for this project
+                    issuesTable =
+                        if Record.HasFields(projectRow, "Issues") and projectRow[Issues] <> null
+                        then projectRow[Issues]
+                        else #table({"id"}, {}),
+
+                    issueIds = 
+                        if Table.RowCount(issuesTable) = 0 then
+                            {}
+                        else if Table.HasColumns(issuesTable, "id") then
+                            List.Transform(
+                                Table.Column(issuesTable, "id"),
+                                each Text.From(_)
+                            )
+                        else {},
+
+                    recordParameters = 
+                        [
+                            ARI = projectAri,
+                            Issues = issueIds,
+                            Creds = accessToken
+                        ],
+                    // Query insights
+                    insightsTable =
+                        if List.IsEmpty(issueIds)
+                        then
+                            #table(
+                                {"id", "description", "created", "updated", "snippets", "IssueId", "HasError", "ErrorMessage"},
+                                {}
+                            )
+                        else 
+                            GetPolarisInsightsForIssues(
+                                projectAri,
+                                issueIds,
+                                accessToken,
+                                true
+                            ),
+                    
+                    // Add project context columns
+                    withProjectContext = Table.AddColumn(
+                        insightsTable,
+                        "ProjectId",
+                        each projectId,
+                        type text
+                    ),
+                    withProjectKey = Table.AddColumn(
+                        withProjectContext,
+                        "ProjectKey",
+                        each projectKey,
+                        type text
+                    ),
+                    withProjectName = Table.AddColumn(
+                        withProjectKey,
+                        "ProjectName",
+                        each projectName,
+                        type text
+                    ),
+                    withProjectAri = Table.AddColumn(
+                        withProjectName,
+                        "ProjectAri", each projectAri,
+                        type text
+                    ),
+                    
+                    // Create summary stats
+                    totalInsights = Table.RowCount(withProjectAri),
+                    issuesWithInsights =
+                        if totalInsights = 0
+                        then 0
+                        else
+                            List.Count(
+                                List.Distinct(
+                                    Table.Column(withProjectAri, "IssueId")
+                                )
+                            ),
+                    
+                    summaryRecord = [
+                        ProjectKey = projectKey,
+                        ProjectName = projectName,
+                        TotalInsights = totalInsights,
+                        IssuesWithInsights = issuesWithInsights,
+                        InsightsTable = withProjectContext,
+                        LastRefreshed = DateTime.LocalNow()
+                    ]
+                in
+                    //[InsightsTbl = insightsTable],
+                    summaryRecord,
+            
+            // Process all JPD projects
+            allProjectInsights = List.Transform(
+                Table.ToRecords(projectsTable),
+                each ProcessJPDProject(_)
+            ),
+            
+            // Create navigation table with summary info
+            navigationRecords = List.Transform(
+                allProjectInsights,
+                each (
+                    let
+                        rec = _
+                    in
+                        [
+                            ProjectKey = rec[ProjectKey],
+                            ProjectName = rec[ProjectName],
+                            TotalInsights = rec[TotalInsights],
+                            IssuesWithInsights = rec[IssuesWithInsights],
+                            LastRefreshed = rec[LastRefreshed]
+                        ]
+                )
+            ),
+            
+            navigationTable = if List.IsEmpty(navigationRecords) then
+                #table(
+                    {"ProjectKey", "ProjectName", "TotalInsights", "IssuesWithInsights", "LastRefreshed"},
+                    {}
+                )
+            else
+                Table.FromRecords(navigationRecords),
+            
+            // Create result record with navigation and individual project tables
+            result = [
+                NavigationTable = navigationTable,
+                ProjectsInsights = Record.FromList(
+                    allProjectInsights,
+                    List.Transform(
+                        allProjectInsights,
+                        each [ProjectKey]
+                    )
+                )
+            ]
+        in
+            //[insghts = allProjectInsights],
+            result,
+    
+    // Error handling wrapper
+    SafeGetAllPolarisInsights = (
+        projectsTable as table,
+        cloudId as text,
+        accessToken as text
+    ) =>
+        let
+            attempt = GetAllPolarisInsights(projectsTable, cloudId, accessToken),
+        //currently bypassed
+            result =
+                if attempt[HasError] then
+                    [
+                        NavigationTable = #table(
+                            {"Error", "Details"},
+                            {
+                                {"Failed to retrieve Polaris insights", attempt[Message] & " (" & attempt[Reason] & ")"}
+                            }
+                        ),
+                        ProjectsInsights = null
+                    ]
+                else
+                    attempt[Value]
+        in
+            attempt
+            //result
+
+in
+    [
+        SafeGetAllPolarisInsights = SafeGetAllPolarisInsights
+    ]

--- a/readme.md
+++ b/readme.md
@@ -2,11 +2,16 @@
 
 A custom Power Query (M) connector for Microsoft Power BI and Excel that integrates with Atlassian Jira Cloud. This README was updated to reflect recent improvements to the project's automated test harness, developer tooling, and developer-friendly helper scripts.
 
-Version: 1.0.7 (connector Version updated in code)
+Version: 1.0.8 (connector Version updated in code)
 
 ## TL;DR — What's new
 
 - OAuth Support
+  - Retrieval of Insights from Jira Product Discovery projects
+    - Only attempts Insight retrieval when OAuth is used for authentication and there is at least one JPD project found in the target proejct(s).
+    - Insights load as a seperate table since it is a 1:* relationship from Issues to Insights.
+    - Detailed Snippet Data (Insights) is stored as ADF, requires significant transformation to make ussable.
+    - Insight code modularized into its own PQM.
   - Authentication workflow moved to its own PQM.
   - Proper handling of URL based on credential Kind.
   - You must define an Application in the Atlassian Developer Console.
@@ -38,8 +43,10 @@ Version: 1.0.7 (connector Version updated in code)
 - **Navigation Table**: Browse projects and issues through an intuitive folder structure
 - **Field Customization**: Specify which Jira fields to retrieve for optimal performance
 - **Project Filtering**: Filter data by specific Jira projects during connection
+- **Custom JQL**:include custom JQL filters and sorting
 - **Dynamic Field Expansion**: Automatically expands nested Jira field structures
-- **Phase 1 MVP**: Works with API token authentication (Phase 2 will add OAuth 3LO support)
+- **JPD Insights Retrieval**: return Insights on Issues from JPD Projects
+- **Phase 2 MVP**: Support for OAuth
 - **Built-in support for mock/test data**: used by the test harness
 
 ## 📋 Prerequisites
@@ -87,6 +94,17 @@ To help with step 2 during development, use the helper script:
    - **Email**: Your Atlassian account email
    - **Instance**: Your Jira URL (e.g., `yourcompany.atlassian.net`)
    - **API Token**: The token you just created
+
+### Set-up credentials for OAuth ###
+
+1. **log in to**: [https://developer.atlassian.com/](https://developer.atlassian.com/)
+2. **Click on Create**: to create a new OAuth 2.0 integration
+3. **Follow steps to**: name your App, set permissions and authorize
+4. **This app requires the following permissions/(Classic) scopes**:
+   - View Jira issue data
+   - View user profiles
+   - Create and manage issues
+5. **Store ID & Key**: store ID and Key in a secure location for use by connector.
 
 ### Connection Parameters
 
@@ -341,9 +359,9 @@ When reporting issues, please include:
 ### Phase 2 🚧 (Planned/Active)
 - [x] OAuth 3LO authentication implementation* (unsecure)
 - [ ] Full pagination support
-- [ ] Jira Product Discovery (JPD) Insights retreival
+- [x] Jira Product Discovery (JPD) Insights retreival
 - [ ] Performance optimizations
-- [X] Advanced filtering options
+- [x] Advanced filtering options
 
 ### Phase 3 🔮 (Future)
 - [ ] Incremental refresh capabilities
@@ -359,4 +377,4 @@ When reporting issues, please include:
 
 ---
 
-*Last updated: October 30, 2025*
+*Last updated: November 5, 2025*


### PR DESCRIPTION
added support to retrieve Insights from Issues in Projects that are Jira Product Discovery projects.

Uses GraphQL as mechanism for data retrieval. Intelligently only executes when there are JPD projects present.