### PR TITLE
Cursor-based pagination and JQL scope control

### DIFF
--- a/atlassianJiraConnector.pq
+++ b/atlassianJiraConnector.pq
@@ -218,12 +218,18 @@ jiraQuery =
             ConvertToTable = Table.FromList(CombinedData, Splitter.SplitByNothing(), null, null, ExtraValues.Error),
             
             // Dynamic field expansion
-            ExpandedTable = 
+            ExpandedTable =
                 let
-                // First expand the main issue fields (id, key, self, fields, etc.)
+                // First expand the main issue fields (id, key, fields, etc.)
+                // self and expand are Jira API internals — excluded unless explicitly requested.
                     firstRecord = if Table.RowCount(ConvertToTable) > 0 then ConvertToTable{0}[Column1] else null,
-                    topLevelFields = if firstRecord <> null then Record.FieldNames(firstRecord) else {},
-                    
+                    allTopLevelFields = if firstRecord <> null then Record.FieldNames(firstRecord) else {},
+                    autoExclude = {"self", "expand", "id"},
+                    topLevelFields = List.Select(allTopLevelFields, each
+                        not List.Contains(autoExclude, _) or
+                        (actualFieldsList <> null and List.Contains(actualFieldsList, _))
+                    ),
+
                     expandedTop = if List.Count(topLevelFields) > 0 then
                         Table.ExpandRecordColumn(ConvertToTable, "Column1", topLevelFields, topLevelFields)
                     else

--- a/atlassianJiraConnector.pq
+++ b/atlassianJiraConnector.pq
@@ -57,7 +57,6 @@ JiraImpl = (
     baseUrl as text,
     fieldList as nullable text,
     projectKeys as nullable text,
-    maxResults as nullable text,
     jqlQuery as nullable text,
     jqlOrderBy as nullable text,
     testDataOverride as nullable record
@@ -65,7 +64,6 @@ JiraImpl = (
     baseUrl,
     fieldList,
     projectKeys,
-    maxResults,
     jqlQuery,
     jqlOrderBy,
     testDataOverride
@@ -77,16 +75,14 @@ shared Jira = (
     #"Company Atlassian URL" as text,
     optional #"Field List (comma separated, e.g., summary,created)" as text,
     optional #"Project Keys (comma separated, e.g., PROJ1,PROJ2)" as text,
-    optional #"Max Number of Results (default: 1000)" as text,
-    optional #"JQL Query String (e.g., status=""Open"")" as text,
-    optional #"JQL Order By String (e.g. priority DESC, created DESC)" as text
+    optional #"JQL Filter (e.g., created>=-365d, status=""Open"") — default: created>=-365d" as text,
+    optional #"JQL Order By (e.g., priority DESC, created DESC)" as text
 ) => jiraNavTbl(
     #"Company Atlassian URL",
     #"Field List (comma separated, e.g., summary,created)",
     #"Project Keys (comma separated, e.g., PROJ1,PROJ2)",
-    #"Max Number of Results (default: 1000)",
-    #"JQL Query String (e.g., status=""Open"")",
-    #"JQL Order By String (e.g. priority DESC, created DESC)",
+    #"JQL Filter (e.g., created>=-365d, status=""Open"") — default: created>=-365d",
+    #"JQL Order By (e.g., priority DESC, created DESC)",
     null
 );
 
@@ -95,12 +91,11 @@ shared JiraTest = (
     #"Company Atlassian URL" as text,
     optional fieldList as text,
     optional projectKeys as text,
-    optional maxResults as text,
     optional jqlQuery as text,
     optional jqlOrderBy as text,
     optional testDataOverride as record
-) => 
-    jiraNavTbl(#"Company Atlassian URL", fieldList, projectKeys, maxResults, jqlQuery, jqlOrderBy, testDataOverride); 
+) =>
+    jiraNavTbl(#"Company Atlassian URL", fieldList, projectKeys, jqlQuery, jqlOrderBy, testDataOverride);
 
 
 
@@ -183,7 +178,6 @@ jiraQuery =
         optional fieldList as nullable list,
         optional jqlString as nullable text,
         optional jqlOrderByString as nullable text,
-        optional maxResults as nullable text,
         optional discoverLimits as nullable logical,
         optional useSimpleRetrieval as nullable logical,
         optional testOverride as nullable record
@@ -194,27 +188,14 @@ jiraQuery =
             actualFieldsList = if fieldList = null then null else fieldList,
             actualJqlString = if jqlString = null then null else jqlString,
             actualJqlOrderBy = if jqlOrderByString = null then null else jqlOrderByString,
-            actualMaxResults = if maxResults = null then "1000" else maxResults,
             shouldDiscoverLimits = if discoverLimits = null then false else discoverLimits,
-            useSimple = if useSimpleRetrieval = null then true else useSimpleRetrieval, // Default to Simple
+            useSimple = if useSimpleRetrieval = null then true else useSimpleRetrieval,
             useTestData = if testOverride = null then null else testOverride,
             fieldsText = if actualFieldsList = null then null else Text.Combine(actualFieldsList, ","),
 
         //somewhere in here build full query
         jqlQuery = buildJqlQuery(actualJqlProjectKey, actualJqlString, actualJqlOrderBy),
 
-        // Dynamic limit discovery (only if requested and JQL is provided)
-            optimalMaxResults =
-                if shouldDiscoverLimits and actualJqlProjectKey <> null
-                    then
-                        try DiscoverMaxResults(url, actualJqlProjectKey, useTestData)
-                        otherwise Number.FromText(actualMaxResults)
-                    else Number.FromText(actualMaxResults), // adjust for Simple
-                        
-            
-            maxResultsText = Number.ToText(optimalMaxResults),
-            maxResultsNumber = Number.FromText(maxResultsText),
-            
         // DATA RETRIEVAL: Choose between simple or paginated
             CombinedData = if useSimple then
                 jiraDataRetrievalSimple(
@@ -222,7 +203,6 @@ jiraQuery =
                     queryPath,
                     jqlQuery,
                     fieldsText,
-                    maxResultsText,
                     useTestData
                 )
             else
@@ -231,8 +211,6 @@ jiraQuery =
                     queryPath,
                     jqlQuery,
                     fieldsText,
-                    maxResultsText,
-                    maxResultsNumber,//why do we need both values? Right now they could be different, again why?
                     useTestData
                 ),
 
@@ -302,7 +280,6 @@ jiraNavTbl =
         companyURL as text,
         optional fields as text,
         optional projectKeys as text,
-        optional maxResults as text,
         optional jqlString as text,
         optional jqlOrderBy as text,
         optional testOverride as nullable record
@@ -337,6 +314,9 @@ jiraNavTbl =
                         )),
                         each _
                     ),
+
+            // Default JQL filter when none is provided — prevents accidental full-table scans.
+            effectiveJql = if jqlString = null or Text.Trim(jqlString) = "" then "created >= -365d" else jqlString,
 
             //if projectKeys = null, then check JQLstring for "project = " if project = is TRUE then get string after project = before AND/OR/(
             //how to extend for multiple project =, use list...
@@ -374,7 +354,6 @@ jiraNavTbl =
                         null, //fieldList
                         null, //jqlString
                         null, //jqlOrderByString
-                        null, //maxResults
                         null, //discoverLimits
                         false, //useSimpleRetrieval
                         null //testOverride
@@ -407,7 +386,7 @@ jiraNavTbl =
                             {"Valid Requested", List.Count(validKeys), Text.Combine(validKeys, ", ")},
                             {"Invalid Requested", List.Count(invalidKeys), Text.Combine(invalidKeys, ", ")},
                             {"Final Project Count", Table.RowCount(filteredProjects), ""},
-                            {"User Supplied JQL String", if jqlString = null then "(none)" else jqlString, "Additional JQL to be applied to issue retrieval"}
+                            {"JQL Filter Applied", effectiveJql, if jqlString = null or Text.Trim(jqlString) = "" then "No filter supplied — defaulted to created >= -365d" else "User supplied"}
                         }
                     )
                 in
@@ -423,18 +402,17 @@ jiraNavTbl =
 
             issues =
                 let
-                    getIssues = Table.AddColumn(getProjects, "Issues", 
+                    getIssues = Table.AddColumn(getProjects, "Issues",
                         each jiraQuery(
-                            URL, 
+                            URL,
                             "rest/api/3/search/jql",
                             "project=" & [key],
                             fieldsDynamic,
-                            jqlString,
-                            jqlOrderBy, //jqlOrderByString
-                            maxResults,
-                            false, // Don't discover limits in Phase 1
-                            true,   // Use simple retrieval
-                            testOverride // PASS TEST OVERRIDE
+                            effectiveJql,
+                            jqlOrderBy,
+                            false,
+                            false,
+                            testOverride
                         )
                     ),
                     issuesWithErrorHandling = Table.TransformColumns(getIssues, {"Issues", each 

--- a/jiraAPI.pqm
+++ b/jiraAPI.pqm
@@ -89,7 +89,6 @@ let
         queryPath as text,
         actualJql as nullable text,
         fieldsText as nullable text,
-        maxResultsText as text,
         optional testOverride as nullable record
     ) =>
         let
@@ -104,7 +103,7 @@ let
                         baseParams = [
                             jql = actualJql,
                             fields = fieldsText,
-                            maxResults = maxResultsText
+                            maxResults = "1000"
                         ],
                         queryParams = Record.RemoveFields(baseParams, 
                             List.Select(Record.FieldNames(baseParams), each Record.Field(baseParams, _) = null)),
@@ -137,8 +136,6 @@ let
         queryPath as text,
         actualJql as nullable text,
         fieldsText as nullable text,
-        maxResultsText as text,
-        maxResultsNumber as number,
         optional testOverride as nullable record
     ) =>
         let
@@ -147,63 +144,127 @@ let
                 ExtractTestIssuesData(testOverride)
             else
                 let
-                    // Build query parameters dynamically, excluding null values
-                    BuildQueryParameters = (startAt as number) =>
+                    // Offset-based params (startAt) for endpoints like /rest/api/3/search
+                    BuildOffsetParams = (startAt as number) =>
                         let
                             baseParams = [
                                 startAt = Number.ToText(startAt),
-                                maxResults = maxResultsText
+                                maxResults = "100"
                             ],
                             withJql = if actualJql <> null then Record.AddField(baseParams, "jql", actualJql) else baseParams,
                             withFields = if fieldsText <> null then Record.AddField(withJql, "fields", fieldsText) else withJql
                         in
                             withFields,
 
-                    GetPage = (startAt as number) =>
+                    // Cursor-based params (nextPageToken) for endpoints like /rest/api/3/search/jql
+                    BuildCursorParams = (nextToken as nullable text) =>
                         let
-                            queryHeaders = [Accept = "application/json"],
-                            queryParameters = BuildQueryParameters(startAt),
-                            source = Web.Contents(
-                                url, [
-                                    RelativePath = queryPath,
-                                    Headers = queryHeaders,
-                                    Query = queryParameters
-                                ]
-                            ),
-                            jsonDoc = Json.Document(source)
+                            baseParams = [maxResults = "100"],
+                            withJql = if actualJql <> null then Record.AddField(baseParams, "jql", actualJql) else baseParams,
+                            withFields = if fieldsText <> null then Record.AddField(withJql, "fields", fieldsText) else withJql,
+                            withToken = if nextToken <> null and nextToken <> "" then Record.AddField(withFields, "nextPageToken", nextToken) else withFields
                         in
-                            jsonDoc,
+                            withToken,
 
+                    GetPage = (startAt as number) =>
+                        Json.Document(Web.Contents(url, [
+                            RelativePath = queryPath,
+                            Headers = [Accept = "application/json"],
+                            Query = BuildOffsetParams(startAt)
+                        ])),
+
+                    GetPageCursor = (nextToken as nullable text) =>
+                        Json.Document(Web.Contents(url, [
+                            RelativePath = queryPath,
+                            Headers = [Accept = "application/json"],
+                            Query = BuildCursorParams(nextToken)
+                        ])),
+
+                    ExtractDataArray = (pageResponse as record) =>
+                        if Record.HasFields(pageResponse, "issues") then pageResponse[issues]
+                        else if Record.HasFields(pageResponse, "values") then pageResponse[values]
+                        else if Record.HasFields(pageResponse, "results") then pageResponse[results]
+                        else null,
+
+                    IsLastPage = (pageResponse as record, startAt as number, pageSize as number) as logical =>
+                        let
+                            items = ExtractDataArray(pageResponse),
+                            count = if items <> null then List.Count(items) else 0
+                        in
+                            if count = 0 then
+                                true
+                            else if Record.HasFields(pageResponse, "total") and pageResponse[total] > 0 then
+                                startAt + count >= pageResponse[total]
+                            else if Record.HasFields(pageResponse, "isLast") then
+                                pageResponse[isLast]
+                            else
+                                count < pageSize,
+
+                    // First request: for cursor endpoints the initial call sends no nextPageToken.
+                    // BuildOffsetParams(0) is fine here — startAt is simply ignored by cursor endpoints.
                     firstResponse = GetPage(0),
                     isDirectArrayResponse = Value.Is(firstResponse, type list),
 
+                    firstPageItems = if not isDirectArrayResponse then ExtractDataArray(firstResponse) else null,
+                    firstPageCount = if firstPageItems <> null then List.Count(firstPageItems) else 0,
+                    rawPageSize =
+                        if not isDirectArrayResponse and Record.HasFields(firstResponse, "maxResults") then
+                            firstResponse[maxResults]
+                        else
+                            50000,
+                    actualPageSize =
+                        if firstPageCount >= 1 then firstPageCount
+                        else if rawPageSize <> null and rawPageSize >= 1 then rawPageSize
+                        else 1,
+
+                    // Detect cursor-based endpoint: /rest/api/3/search/jql returns nextPageToken;
+                    // /rest/api/3/search returns total. Sending startAt to the cursor endpoint is
+                    // ignored by Jira, causing every "next page" to return the same first page.
+                    isCursorBased = not isDirectArrayResponse and Record.HasFields(firstResponse, "nextPageToken"),
+
+                    // Cursor-based loop: use nextPageToken from each response.
+                    CursorPages = List.Generate(
+                        () => [Page = firstResponse, ItemsSoFar = 0, Done = false],
+                        each not [Done] and [Page] <> null,
+                        each
+                            let
+                                pageItems = ExtractDataArray([Page]),
+                                pageCount = if pageItems <> null then List.Count(pageItems) else 0,
+                                newTotal  = [ItemsSoFar] + pageCount,
+                                isLast    = if Record.HasFields([Page], "isLast") then [Page][isLast] else true,
+                                rawToken  = if Record.HasFields([Page], "nextPageToken") then [Page][nextPageToken] else null,
+                                nextToken = if rawToken <> null and rawToken <> "" then rawToken else null,
+                                done      = isLast or nextToken = null
+                            in
+                                if done then
+                                    [Page = null, ItemsSoFar = newTotal, Done = true]
+                                else
+                                    [Page = GetPageCursor(nextToken), ItemsSoFar = newTotal, Done = false],
+                        each ExtractDataArray([Page])
+                    ),
+
+                    // Offset-based loop: increment startAt by actualPageSize each request.
+                    OffsetPages = List.Generate(
+                        () => [Page = firstResponse, StartAt = 0, Done = false],
+                        each not [Done] and [Page] <> null,
+                        each
+                            let
+                                nextStart = [StartAt] + actualPageSize,
+                                done      = IsLastPage([Page], [StartAt], actualPageSize)
+                            in
+                                if done then
+                                    [Page = null, StartAt = nextStart, Done = true]
+                                else
+                                    [Page = GetPage(nextStart), StartAt = nextStart, Done = false],
+                        each ExtractDataArray([Page])
+                    ),
+
                     GetAllPages = if isDirectArrayResponse then
                         {firstResponse}
+                    else if isCursorBased then
+                        CursorPages
                     else
-                        let
-                            ExtractDataArray = (pageResponse as record) =>
-                                if Record.HasFields(pageResponse, "issues") then pageResponse[issues]
-                                else if Record.HasFields(pageResponse, "values") then pageResponse[values]  
-                                else if Record.HasFields(pageResponse, "results") then pageResponse[results]
-                                else null,
-                            
-                            isPaginated = Record.HasFields(firstResponse, "isLast") or Record.HasFields(firstResponse, "total")
-                        in
-                            if isPaginated then
-                                List.Generate(
-                                    () => [Page = firstResponse, StartAt = 0],
-                                    each [Page] <> null and 
-                                        ExtractDataArray([Page]) <> null and
-                                        ([Page][isLast]? <> true),
-                                    each 
-                                        let
-                                            nextStartAt = [StartAt] + maxResultsNumber
-                                        in
-                                            [Page = GetPage(nextStartAt), StartAt = nextStartAt],
-                                    each ExtractDataArray([Page])
-                                )
-                            else
-                                {ExtractDataArray(firstResponse)}
+                        OffsetPages
                 in
                     List.Combine(List.RemoveNulls(GetAllPages))
         in

--- a/jiraSchema.pqm
+++ b/jiraSchema.pqm
@@ -26,33 +26,34 @@ let
             }
         ),
 
-    // Infer types from field names and sample data
+    // Infer types from field names and value shape.
+    // For custom fields without a "date" in the name, detect ISO 8601 datetime strings
+    // by structure (YYYY-MM-DDTHH…) rather than by trying to parse the value — avoids
+    // mis-typing text fields whose content happens to be parseable as a date.
     InferJiraFieldType = (fieldName as text, sampleValue as any) as type =>
         let
             lowerFieldName = Text.Lower(fieldName),
-            
-            // Custom field pattern recognition
-            typeFromName = if Text.StartsWith(lowerFieldName, "customfield_") then
-                if Text.Contains(lowerFieldName, "date") then type datetimezone
-                else if Text.Contains(lowerFieldName, "number") then type number
-                else if Text.Contains(lowerFieldName, "user") then type any
-                else type any
-            else type any,
-                
-            // Sample value analysis
-            typeFromValue = if typeFromName = type any then
-                if sampleValue is text then
-                    if try DateTime.FromText(sampleValue) <> null otherwise false then
-                        type datetimezone
-                    else if try Number.FromText(sampleValue) <> null otherwise false then
-                        type number
-                    else type text
+            typeFromName =
+                if Text.StartsWith(lowerFieldName, "customfield_") then
+                    if Text.Contains(lowerFieldName, "date") then type datetimezone
+                    else type any
+                else type any,
+            // ISO 8601: positions 4, 7 = "-" and position 10 = "T"
+            isIso8601Text =
+                sampleValue is text and
+                Text.Length(sampleValue) >= 20 and
+                Text.At(sampleValue, 4)  = "-" and
+                Text.At(sampleValue, 7)  = "-" and
+                Text.At(sampleValue, 10) = "T",
+            typeFromValue =
+                if typeFromName <> type any then typeFromName
+                else if isIso8601Text then type datetimezone
+                else if sampleValue is text then type text
                 else if sampleValue is number then type number
                 else if sampleValue is list then type any
                 else if sampleValue is record then type any
                 else if sampleValue is table then type any
                 else type any
-            else typeFromName
         in
             typeFromValue,
 

--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,9 @@ Version: 1.0.9 (connector Version updated in code)
       - Browse to the *.mez connector file.
       - Open in Winzip (or other archive tool); or modify the file extension to *.zip, (revert for implementation/use in Power BI / Power BI Gateway)
       - Copy ID and Secret file into the zip (*.mez) archive
+- **Full pagination support** is now implemented — the connector automatically pages through all results using either cursor-based (`nextPageToken`) or offset-based (`startAt`) pagination depending on the endpoint. There is no longer a cap on the number of issues returned per project.
+- **`Max Number of Results` parameter removed** — result scope is now controlled via JQL filters instead of a hard row limit.
+- **Default JQL filter** — when no JQL filter is provided, the connector automatically applies `created >= -365d`. This prevents accidental full-table scans and keeps initial loads fast. Override by supplying your own JQL filter string.
 - Support for Custom Sort Order
   - Sort by any valid fields, ASC or DESC
   - Combine multiple sorts into a single statement.
@@ -43,14 +46,16 @@ Version: 1.0.9 (connector Version updated in code)
 
 ## 🚀 Features
 
-- **Direct Jira Integration**: Connect to any Jira Cloud instance using API tokens
+- **Direct Jira Integration**: Connect to any Jira Cloud instance using API tokens or OAuth
+- **Full Pagination**: Automatically fetches all pages of results — no row cap, no manual configuration required
+- **Default Date Filter**: Applies `created >= -365d` when no JQL is provided to avoid accidental full-table scans
 - **Navigation Table**: Browse projects and issues through an intuitive folder structure
 - **Field Customization**: Specify which Jira fields to retrieve for optimal performance
 - **Project Filtering**: Filter data by specific Jira projects during connection
-- **Custom JQL**:include custom JQL filters and sorting
+- **Custom JQL**: Include custom JQL filters and sorting; defaults to last 365 days when omitted
 - **Dynamic Field Expansion**: Automatically expands nested Jira field structures
-- **JPD Insights Retrieval**: return Insights on Issues from JPD Projects
-- **Phase 2 MVP**: Support for OAuth
+- **JPD Insights Retrieval**: return Insights on Issues from JPD Projects (OAuth only)
+- **Support for OAuth**: 3-legged OAuth 2.0 flow
 - **Built-in support for mock/test data**: used by the test harness
 
 ## 📋 Prerequisites
@@ -116,12 +121,11 @@ When connecting through Power BI:
 
 | Parameter | Description | Example |
 |-----------|-------------|---------|
-| **Company URL Identifier** | Your Jira instance name (without `.atlassian.net`) | `acmesoftware` |
+| **Company URL Identifier** | Your Jira instance URL (full `https://` string required) | `https://acmesoftware.atlassian.net` |
 | **Field List** (Optional) | Comma-separated list of Jira fields to retrieve | `id,key,summary,created,assignee` |
 | **Project Keys** (Optional) | Comma-separated list of project keys to filter | `PROJECT1,PROJECT2` |
-| **Max Number of Results** (Optional) | Numerical value for the number of results to return from each Jira project, default is 1,000 | `2000` |
-| **JQL Query String** (optional) | Custom JQL query string, appended to base query with an ```AND``` wrapped in Parenthesis ```()```, **DO NOT** include a project arguement. | `status = "In Progress"` |
-| **JQL Order By String** (optional) | Custom JQL ORDER BY string, automatically appended to end of JQL query. Supports ASC and DESC, multiple fields | '"created DESC, priority DESC"' |
+| **JQL Filter** (Optional) | Custom JQL filter, appended to the project key with `AND` and wrapped in `()`. **DO NOT** include a `project` argument. Defaults to `created >= -365d` when left blank. | `status = "In Progress"` |
+| **JQL Order By** (Optional) | Custom JQL `ORDER BY` clause, appended to the end of the query. Supports `ASC`/`DESC` and multiple fields. | `created DESC, priority DESC` |
 
 ### Authentication
 
@@ -194,18 +198,17 @@ CI Suggestions
 ## 📊 Usage Examples
 
 ### Basic Connection
-Company URL Identifier: mycompany
+Company URL: https://mycompany.atlassian.net
 Field List: (leave blank for default fields) - id, key, summary, description, issuetype, created, components
 Project Keys: (leave blank for all projects)
-Max Results: (leave blank to return 1,000 rows)
-JQL Query String: (leave blank to return the top N rows from each project)
+JQL Filter: (leave blank — defaults to `created >= -365d`)
 
 ### Specific Projects with Custom Fields
-Company URL Identifier: mycompany
+Company URL: https://mycompany.atlassian.net
 Field List: id,key,summary,status,assignee,created,updated
 Project Keys: PROJ1,PROJ2,WEBDEV
-JQL Query String: (status="In Progress") OR (priority="Major")
-JQL Order By String: created DESC, priority DESC
+JQL Filter: (status="In Progress") OR (priority="Major")
+JQL Order By: created DESC, priority DESC
 
 ## 🏗️ Architecture
 
@@ -240,8 +243,8 @@ atlassianJiraConnector/
 ### Key Components
 
 #### Data Retrieval
-- **Phase 1**: `jiraDataRetrievalSimple()` - Single API calls (current)
-- **Phase 2**: `jiraDataRetrievalPaginated()` - Full pagination (OAuth)
+- **`jiraDataRetrievalPaginated()`** — Full pagination (used for issue queries). Supports both cursor-based (`nextPageToken`, used by `/rest/api/3/search/jql`) and offset-based (`startAt`, used by `/rest/api/3/search`) endpoints. Fetches all pages automatically.
+- **`jiraDataRetrievalSimple()`** — Single-request retrieval, used only for project listing and similar non-paginated endpoints.
 
 #### Core Functions
 - **`jiraQuery()`**: Universal query function with transformation
@@ -250,20 +253,21 @@ atlassianJiraConnector/
 
 ## 📈 Performance Considerations
 
-### Current Limitations (Phase 1)
-- **Maximum ~1000-2000 issues per project** (API token limitation)
-- **No automatic pagination** (single large requests)
-- **Sequential project processing** (not parallelized)
+### Pagination
+The connector automatically fetches all pages of results — there is no hard row cap. Each page request fetches up to 100 issues.
+
+- For large projects, use the **JQL Filter** to narrow the result set (e.g., `created >= -90d`, `status = "In Progress"`).
+- The default filter `created >= -365d` is applied automatically when no JQL is provided.
 
 ### Optimization Tips
-- Use **Project Keys** parameter to limit scope
-- Specify **Field List** to reduce payload size
-- Consider breaking large projects into smaller queries
+- Use **Project Keys** to limit scope to the projects you need
+- Specify **Field List** to reduce payload size per issue
+- Use a tighter JQL date range for very large projects (> 10,000 issues)
+- Sequential project processing (not parallelized) — fetching many projects in one load will take proportionally longer
 
-### Phase 2 Improvements (Planned)
-- **OAuth 3LO Authentication** for unlimited pagination
-- **Jira Product Discovery Insights** retrieve via Polaris Graphql endpoints
-- **Incremental refresh support**
+### Known Limitations
+- **Sequential project processing** — projects are loaded one at a time, not in parallel
+- **Incremental refresh** — not yet supported; each refresh re-fetches from the API
 
 ## 🔒 Security
 
@@ -362,7 +366,7 @@ When reporting issues, please include:
 
 ### Phase 2 🚧 (Planned/Active)
 - [x] OAuth 3LO authentication implementation* (unsecure)
-- [ ] Full pagination support
+- [x] Full pagination support (cursor-based and offset-based)
 - [x] Jira Product Discovery (JPD) Insights retreival
 - [ ] Performance optimizations
 - [x] Advanced filtering options
@@ -380,5 +384,3 @@ When reporting issues, please include:
 **Repository**: [GitHub Repository URL]
 
 ---
-
-*Last updated: November 10, 2025*


### PR DESCRIPTION
- Fix duplicate-row bug: /rest/api/3/search/jql is cursor-based and ignores startAt; connector now detects nextPageToken and follows pages until isLast=true. Offset-based fallback retained for legacy endpoints that return total instead of nextPageToken.
- Remove maxResults parameter from public connector signature (Jira, JiraTest, jiraNavTbl, jiraQuery). Scope is now controlled by JQL.
- Add default JQL filter (created >= -365d) when no filter is supplied to prevent accidental full-table scans on large projects.
- Remove internal safety caps from pagination loops; termination relies on Jira API signals only.
- Used Claude to update readme: pagination behaviour, default JQL filter